### PR TITLE
Adding the capability of translating files by append language code.

### DIFF
--- a/lang/en/local_staticpage.php
+++ b/lang/en/local_staticpage.php
@@ -65,6 +65,7 @@ $string['processfiltersyes'] = 'Yes, process filters';
 $string['settingspagelist'] = 'List of static pages';
 $string['settingspagelistentryfilename'] = 'The following document file was found:<br /><strong>{$a}</strong>';
 $string['settingspagelistentrypagename'] = 'From the document file\'s filename, Moodle derived the following pagename:<br /><strong>{$a}</strong>';
+$string['settingspagelistentrypagelanguages'] = 'Translations found:<br /><strong>{$a}</strong>';
 $string['settingspagelistentryrewritedisabled'] = 'The static page should be available at the following clean URL, but is not verified because checking availability is disabled:<br /><strong>{$a}</strong>';
 $string['settingspagelistentryrewriteerror'] = 'The static page should be available at the following clean URL, but actually a browser won\'t be able to download and view it either because of connection error or responding slower than checkavailabilitytimeout config (perhaps there is something wrong with your webserver or mod_rewrite configuration):<br /><strong>{$a}</strong>';
 $string['settingspagelistentryrewritefail'] = 'The static page should be available at the following clean URL, but actually a browser won\'t be able to download and view it due to a non-2xx HTTP status code (perhaps there is something wrong with your webserver or mod_rewrite configuration):<br /><strong>{$a}</strong>';

--- a/settings_pagelist.php
+++ b/settings_pagelist.php
@@ -81,6 +81,30 @@ if ($fs->is_area_empty($context->id, 'local_staticpage', 'documents')) {
     // Get plugin config.
     $localstaticpageconfig = get_config('local_staticpage');
 
+    // Initialize page and language variables
+    $pageLanguages = [];
+    $pageName = '';
+
+    // Preprocess $pages array to remove translations from the list
+    foreach ($pages as $key => $page) {
+
+        // Collect information about the page.
+        $fileName = $page->get_filename();
+        $pageName = pathinfo($fileName, PATHINFO_FILENAME);
+
+        // Check if the page is a translation.
+        if (preg_match('/--[a-zA-Z]{2}$/', $pageName, $matches)) {
+            // Get the language code.
+            $language = substr($matches[0], 2);
+            // Get the default page name
+            $defaultPageName = substr($pageName, 0, -4);
+            // Add the language to the list.
+            $pageLanguages[$defaultPageName][] = $language;
+            // Remove the translation from the list
+            unset($pages[$key]);
+        }
+    }
+
     // Output each page as a page list entry.
     foreach ($pages as $page) {
 
@@ -100,6 +124,10 @@ if ($fs->is_area_empty($context->id, 'local_staticpage', 'documents')) {
         // Print basic information about the page.
         $html .= html_writer::tag('p', get_string('settingspagelistentryfilename', 'local_staticpage', $pagefilename));
         $html .= html_writer::tag('p', get_string('settingspagelistentrypagename', 'local_staticpage', $pagepagename));
+
+        if (array_key_exists($pagepagename, $pageLanguages)) {
+            $html .= html_writer::tag('p', get_string('settingspagelistentrypagelanguages', 'local_staticpage', implode(', ', $pageLanguages[$pagepagename])));
+        }
 
         // Print normal static page URL - Do only if apache rewrite isn't forced.
         if (!$localstaticpageconfig->apacherewrite) {

--- a/view.php
+++ b/view.php
@@ -66,6 +66,18 @@ $context = \context_system::instance();
 // Get filearea.
 $fs = get_file_storage();
 
+// Get current language
+$lang = current_language();
+
+// Get translated file
+$filename_traslated = "$page--$lang.html";
+$file = $fs->get_file($context->id, 'local_staticpage', 'documents', 0, '/', $filename_traslated);
+
+// If translated file exists replace default filename
+if ($file) {
+    $filename = $filename_traslated;
+}
+
 // Get document from filearea.
 $file = $fs->get_file($context->id, 'local_staticpage', 'documents', 0, '/', $filename);
 


### PR DESCRIPTION
Adding the capability of translating files by append language code.

For instance, adding the following files to documents:
- test.html
- test--fr.html
- test--es.html

Will result in displaying just "my-content" in document list, but with "es" and "fr" translations found.

![image](https://github.com/user-attachments/assets/20501038-1332-4634-8e17-e57125aa7b93)

Default site language will load base file "test.html". If language is swiched, the system will try to load "test--**.html" depending on current language. If there is no file available for current language it will load default file.